### PR TITLE
Allow options in command, add travis integration, and update readme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.DS_Store
+.idea/
+vendor/

--- a/.htaccess
+++ b/.htaccess
@@ -1,0 +1,154 @@
+#
+# Apache/PHP/Drupal settings:
+#
+
+# Protect files and directories from prying eyes.
+<FilesMatch "\.(engine|inc|info|install|make|module|profile|test|po|sh|.*sql|theme|tpl(\.php)?|xtmpl)(~|\.sw[op]|\.bak|\.orig|\.save)?$|^(\.(?!well-known).*|Entries.*|Repository|Root|Tag|Template|composer\.(json|lock))$|^#.*#$|\.php(~|\.sw[op]|\.bak|\.orig\.save)$">
+  <IfModule mod_authz_core.c>
+    Require all denied
+  </IfModule>
+  <IfModule !mod_authz_core.c>
+    Order allow,deny
+  </IfModule>
+</FilesMatch>
+
+# Don't show directory listings for URLs which map to a directory.
+Options -Indexes
+
+# Follow symbolic links in this directory.
+Options +FollowSymLinks
+
+# Make Drupal handle any 404 errors.
+ErrorDocument 404 /index.php
+
+# Set the default handler.
+DirectoryIndex index.php index.html index.htm
+
+# Override PHP settings that cannot be changed at runtime. See
+# sites/default/default.settings.php and drupal_environment_initialize() in
+# includes/bootstrap.inc for settings that can be changed at runtime.
+
+# PHP 5, Apache 1 and 2.
+<IfModule mod_php5.c>
+  php_flag magic_quotes_gpc                 off
+  php_flag magic_quotes_sybase              off
+  php_flag register_globals                 off
+  php_flag session.auto_start               off
+  php_value mbstring.http_input             pass
+  php_value mbstring.http_output            pass
+  php_flag mbstring.encoding_translation    off
+</IfModule>
+
+# Requires mod_expires to be enabled.
+<IfModule mod_expires.c>
+  # Enable expirations.
+  ExpiresActive On
+
+  # Cache all files for 2 weeks after access (A).
+  ExpiresDefault A1209600
+
+  <FilesMatch \.php$>
+    # Do not allow PHP scripts to be cached unless they explicitly send cache
+    # headers themselves. Otherwise all scripts would have to overwrite the
+    # headers set by mod_expires if they want another caching behavior. This may
+    # fail if an error occurs early in the bootstrap process, and it may cause
+    # problems if a non-Drupal PHP file is installed in a subdirectory.
+    ExpiresActive Off
+  </FilesMatch>
+</IfModule>
+
+# Various rewrite rules.
+<IfModule mod_rewrite.c>
+  RewriteEngine on
+
+  # Set "protossl" to "s" if we were accessed via https://.  This is used later
+  # if you enable "www." stripping or enforcement, in order to ensure that
+  # you don't bounce between http and https.
+  RewriteRule ^ - [E=protossl]
+  RewriteCond %{HTTPS} on
+  RewriteRule ^ - [E=protossl:s]
+
+  # Make sure Authorization HTTP header is available to PHP
+  # even when running as CGI or FastCGI.
+  RewriteRule ^ - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]
+
+  # Block access to "hidden" directories whose names begin with a period. This
+  # includes directories used by version control systems such as Subversion or
+  # Git to store control files. Files whose names begin with a period, as well
+  # as the control files used by CVS, are protected by the FilesMatch directive
+  # above.
+  #
+  # NOTE: This only works when mod_rewrite is loaded. Without mod_rewrite, it is
+  # not possible to block access to entire directories from .htaccess, because
+  # <DirectoryMatch> is not allowed here.
+  #
+  # If you do not have mod_rewrite installed, you should remove these
+  # directories from your webroot or otherwise protect them from being
+  # downloaded.
+  RewriteRule "/\.|^\.(?!well-known/)" - [F]
+
+  # If your site can be accessed both with and without the 'www.' prefix, you
+  # can use one of the following settings to redirect users to your preferred
+  # URL, either WITH or WITHOUT the 'www.' prefix. Choose ONLY one option:
+  #
+  # To redirect all users to access the site WITH the 'www.' prefix,
+  # (http://example.com/... will be redirected to http://www.example.com/...)
+  # uncomment the following:
+  # RewriteCond %{HTTP_HOST} .
+  # RewriteCond %{HTTP_HOST} !^www\. [NC]
+  # RewriteRule ^ http%{ENV:protossl}://www.%{HTTP_HOST}%{REQUEST_URI} [L,R=301]
+  #
+  # To redirect all users to access the site WITHOUT the 'www.' prefix,
+  # (http://www.example.com/... will be redirected to http://example.com/...)
+  # uncomment the following:
+  # RewriteCond %{HTTP_HOST} ^www\.(.+)$ [NC]
+  # RewriteRule ^ http%{ENV:protossl}://%1%{REQUEST_URI} [L,R=301]
+
+  # Modify the RewriteBase if you are using Drupal in a subdirectory or in a
+  # VirtualDocumentRoot and the rewrite rules are not working properly.
+  # For example if your site is at http://example.com/drupal uncomment and
+  # modify the following line:
+  # RewriteBase /drupal
+  #
+  # If your site is running in a VirtualDocumentRoot at http://example.com/,
+  # uncomment the following line:
+  # RewriteBase /
+
+  # Pass all requests not referring directly to files in the filesystem to
+  # index.php. Clean URLs are handled in drupal_environment_initialize().
+  RewriteCond %{REQUEST_FILENAME} !-f
+  RewriteCond %{REQUEST_FILENAME} !-d
+  RewriteCond %{REQUEST_URI} !=/favicon.ico
+  RewriteRule ^ index.php [L]
+
+  # Rules to correctly serve gzip compressed CSS and JS files.
+  # Requires both mod_rewrite and mod_headers to be enabled.
+  <IfModule mod_headers.c>
+    # Serve gzip compressed CSS files if they exist and the client accepts gzip.
+    RewriteCond %{HTTP:Accept-encoding} gzip
+    RewriteCond %{REQUEST_FILENAME}\.gz -s
+    RewriteRule ^(.*)\.css $1\.css\.gz [QSA]
+
+    # Serve gzip compressed JS files if they exist and the client accepts gzip.
+    RewriteCond %{HTTP:Accept-encoding} gzip
+    RewriteCond %{REQUEST_FILENAME}\.gz -s
+    RewriteRule ^(.*)\.js $1\.js\.gz [QSA]
+
+    # Serve correct content types, and prevent mod_deflate double gzip.
+    RewriteRule \.css\.gz$ - [T=text/css,E=no-gzip:1]
+    RewriteRule \.js\.gz$ - [T=text/javascript,E=no-gzip:1]
+
+    <FilesMatch "(\.js\.gz|\.css\.gz)$">
+      # Serve correct encoding type.
+      Header set Content-Encoding gzip
+      # Force proxies to cache gzipped & non-gzipped css/js files separately.
+      Header append Vary Accept-Encoding
+    </FilesMatch>
+  </IfModule>
+</IfModule>
+
+# Add headers to all responses.
+<IfModule mod_headers.c>
+  # Disable content sniffing, since it's an attack vector.
+  Header always set X-Content-Type-Options nosniff
+</IfModule>

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,34 @@
+language: php
+
+php:
+  - 7.0
+  - 7.1
+  - 7.2
+
+matrix:
+  include:
+    - php: 7.0
+    - php: 7.1
+    - php: 7.2
+
+services:
+  - postgresql
+
+before_script:
+  - psql -c 'create database travis_ci_test;' -U postgres
+  - psql -c "alter role postgres with password 'dbpass'"
+  - composer install
+
+script:
+  - ./vendor/bin/drush --include=. tripal-generic-install \
+                       --interactive=0 \
+                       --site-name="tripal 3 test" \
+                       --site-email="test@example.com" \
+                       --admin-username="admin" \
+                       --admin-password="adminpass" \
+                       --db-name="travis_ci_test" \
+                       --db-host="127.0.0.1" \
+                       --db-port="5432" \
+                       --db-username="postgres" \
+                       --db-password="dbpass" \
+                       --chado-version=1

--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
 # tripal_install
 Tripal Install Profiles
+
+## Documentation
+Full installation instructions can be found in our [user guide](http://tripal.info/tutorials/v3.x/installation/rapid)

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,5 @@
+{
+    "require-dev": {
+        "drush/drush": "7"
+    }
+}

--- a/composer.lock
+++ b/composer.lock
@@ -1,0 +1,369 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "6bb5e048e3e2184b00222740272dd205",
+    "packages": [],
+    "packages-dev": [
+        {
+            "name": "d11wtq/boris",
+            "version": "v1.0.10",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/borisrepl/boris.git",
+                "reference": "31055b15e2d3fe47f31f6aa8e277f8f3fc7eb483"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/borisrepl/boris/zipball/31055b15e2d3fe47f31f6aa8e277f8f3fc7eb483",
+                "reference": "31055b15e2d3fe47f31f6aa8e277f8f3fc7eb483",
+                "shasum": ""
+            },
+            "require": {
+                "ext-pcntl": "*",
+                "ext-posix": "*",
+                "ext-readline": "*",
+                "php": ">=5.3.0"
+            },
+            "bin": [
+                "bin/boris"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "Boris": "lib"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "A tiny, but robust REPL (Read-Evaluate-Print-Loop) for PHP.",
+            "time": "2015-03-01T08:05:19+00:00"
+        },
+        {
+            "name": "drush/drush",
+            "version": "7.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/drush-ops/drush.git",
+                "reference": "02a9841b29daba7b55295903c1c4b0a45c9abdc5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/drush-ops/drush/zipball/02a9841b29daba7b55295903c1c4b0a45c9abdc5",
+                "reference": "02a9841b29daba7b55295903c1c4b0a45c9abdc5",
+                "shasum": ""
+            },
+            "require": {
+                "d11wtq/boris": "~1.0",
+                "pear/console_table": "~1.2.0",
+                "php": ">=5.3.0",
+                "symfony/var-dumper": "^2.6.3",
+                "symfony/yaml": "~2.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": ">=3.5",
+                "symfony/process": "2.4.5"
+            },
+            "bin": [
+                "drush",
+                "drush.php",
+                "drush.bat",
+                "drush.complete.sh"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "7.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Drush": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0+"
+            ],
+            "authors": [
+                {
+                    "name": "Moshe Weitzman",
+                    "email": "weitzman@tejasa.com"
+                },
+                {
+                    "name": "Owen Barton",
+                    "email": "drupal@owenbarton.com"
+                },
+                {
+                    "name": "Mark Sonnabaum",
+                    "email": "marksonnabaum@gmail.com"
+                },
+                {
+                    "name": "Antoine Beaupré",
+                    "email": "anarcat@koumbit.org"
+                },
+                {
+                    "name": "Greg Anderson",
+                    "email": "greg.1.anderson@greenknowe.org"
+                },
+                {
+                    "name": "Jonathan Araña Cruz",
+                    "email": "jonhattan@faita.net"
+                },
+                {
+                    "name": "Jonathan Hedstrom",
+                    "email": "jhedstrom@gmail.com"
+                },
+                {
+                    "name": "Christopher Gervais",
+                    "email": "chris@ergonlogic.com"
+                }
+            ],
+            "description": "Drush is a command line shell and scripting interface for Drupal, a veritable Swiss Army knife designed to make life easier for those of us who spend some of our working hours hacking away at the command prompt.",
+            "homepage": "http://www.drush.org",
+            "time": "2015-05-20T14:23:37+00:00"
+        },
+        {
+            "name": "pear/console_table",
+            "version": "v1.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/pear/Console_Table.git",
+                "reference": "a129a91d8bf19317d81e68d1d3a2e18932f684e4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/pear/Console_Table/zipball/a129a91d8bf19317d81e68d1d3a2e18932f684e4",
+                "reference": "a129a91d8bf19317d81e68d1d3a2e18932f684e4",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=4.3.10"
+            },
+            "suggest": {
+                "pear/Console_Color2": ">=0.1.2"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "Table.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-2-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Jan Schneider",
+                    "homepage": "http://pear.php.net/user/yunosh"
+                },
+                {
+                    "name": "Tal Peer",
+                    "homepage": "http://pear.php.net/user/tal"
+                },
+                {
+                    "name": "Xavier Noguer",
+                    "homepage": "http://pear.php.net/user/xnoguer"
+                },
+                {
+                    "name": "Richard Heyes",
+                    "homepage": "http://pear.php.net/user/richard"
+                }
+            ],
+            "description": "Library that makes it easy to build console style tables.",
+            "homepage": "http://pear.php.net/package/Console_Table/",
+            "keywords": [
+                "console"
+            ],
+            "time": "2014-10-27T09:53:49+00:00"
+        },
+        {
+            "name": "symfony/polyfill-mbstring",
+            "version": "v1.7.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-mbstring.git",
+                "reference": "78be803ce01e55d3491c1397cf1c64beb9c1b63b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/78be803ce01e55d3491c1397cf1c64beb9c1b63b",
+                "reference": "78be803ce01e55d3491c1397cf1c64beb9c1b63b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "suggest": {
+                "ext-mbstring": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.7-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Mbstring\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for the Mbstring extension",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "mbstring",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "time": "2018-01-30T19:27:44+00:00"
+        },
+        {
+            "name": "symfony/var-dumper",
+            "version": "v2.8.36",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/var-dumper.git",
+                "reference": "e6a3e8c832096f8902a3e80169fca5d202e7e0d3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/e6a3e8c832096f8902a3e80169fca5d202e7e0d3",
+                "reference": "e6a3e8c832096f8902a3e80169fca5d202e7e0d3",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.9",
+                "symfony/polyfill-mbstring": "~1.0"
+            },
+            "conflict": {
+                "phpunit/phpunit": "<4.8.35|<5.4.3,>=5.0"
+            },
+            "require-dev": {
+                "ext-iconv": "*",
+                "twig/twig": "~1.34|~2.4"
+            },
+            "suggest": {
+                "ext-iconv": "To convert non-UTF-8 strings to UTF-8 (or symfony/polyfill-iconv in case ext-iconv cannot be used).",
+                "ext-symfony_debug": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.8-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "Resources/functions/dump.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Component\\VarDumper\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony mechanism for exploring and dumping PHP variables",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "debug",
+                "dump"
+            ],
+            "time": "2018-01-31T10:36:06+00:00"
+        },
+        {
+            "name": "symfony/yaml",
+            "version": "v2.8.36",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/yaml.git",
+                "reference": "be720fcfae4614df204190d57795351059946a77"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/be720fcfae4614df204190d57795351059946a77",
+                "reference": "be720fcfae4614df204190d57795351059946a77",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.9"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.8-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Yaml\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Yaml Component",
+            "homepage": "https://symfony.com",
+            "time": "2018-01-03T07:36:31+00:00"
+        }
+    ],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": [],
+    "platform-dev": []
+}

--- a/tripal_install.drush.inc
+++ b/tripal_install.drush.inc
@@ -29,36 +29,127 @@
  * See `drush topic docs-commands` for a list of recognized keys.
  */
 function tripal_install_drush_command() {
-  $items = array();
-  $items['install-prepare'] = array(
+  $items = [];
+  $items['install-prepare'] = [
     'description' => "Installs Chado and Prepares the Site.",
-    'examples' => array(
+    'examples' => [
       'drush tripal-generic-install',
-    ),
-    'aliases' => array('tripal-generic-install'),
+    ],
+    'aliases' => ['tripal-generic-install'],
     // No bootstrap at all.
     'bootstrap' => DRUSH_BOOTSTRAP_NONE,
-  );
+    'options' => [
+      // (int) whether to run the command interactively
+      'interactive' => 'Whether to run the command interactively. Choose between 1 or 0 for true and false respectively',
+
+      // (string) Site information
+      'site-name' => 'Specifies the site name',
+      'site-email' => 'Specifies the site email',
+      'admin-username' => 'Specifies the administrator\'s username',
+      'admin-password' => 'Specifies the administrator\'s password',
+
+      // (string) Database information
+      'db-name' => 'Specifies the database name',
+      'db-host' => 'Specifies the database host',
+      'db-port' => 'Specifies the database port',
+      'db-username' => 'Specifies the database username',
+      'db-password' => 'Specifies the database password',
+
+      // (int) Chado version. Options from 0 to 3 corresponding to the following
+      // 0 - cancel
+      // 1 - chado 1.3
+      // 2 - chado 1.2
+      // 3 - chado 1.11
+      'chado-version' => 'Specifies the chado database version. Available options are 0 for skip installation, 1 for chado 1.3, 2 for chado 1.2 and 3 for chado 1.11.',
+    ],
+  ];
   return $items;
 }
 
 /**
  * Implements drush_hook_COMMAND().
  *
- *
  * @see drush_invoke()
  * @see drush.api.php
  */
-
 function drush_tripal_install_install_prepare() {
+  $interactive = drush_get_option('interactive', TRUE);
+  try {
+    if ($interactive) {
+      $settings = tripal_install_get_settings_interactively();
+    }
+    else {
+      $settings = tripal_install_get_inline_settings();
+    }
+
+    // Do the install
+    tripal_install_perform_tasks($settings);
+  } catch (Exception $exception) {
+    drush_log($exception->getMessage(), 'error');
+    return;
+  }
+}
+
+/**
+ * Get settings from the command options.
+ *
+ * @return array
+ * @throws \Exception
+ */
+function tripal_install_get_inline_settings() {
+  // Validate all options
+  $options = [
+    'site-name' => drush_get_option('site-name'),
+    'site-email' => drush_get_option('site-email'),
+    'admin-username' => drush_get_option('admin-username'),
+    'admin-password' => drush_get_option('admin-password'),
+    'db-host' => drush_get_option('db-host'),
+    'db-port' => drush_get_option('db-port'),
+    'db-name' => drush_get_option('db-name'),
+    'db-username' => drush_get_option('db-username'),
+    'db-password' => drush_get_option('db-password'),
+    'chado-version' => drush_get_option('chado-version'),
+  ];
+
+  $has_errors = FALSE;
+  foreach ($options as $option => $value) {
+    if (!$value) {
+      drush_log("Option --{$option} is required in non-interactive mode.", 'error');
+      $has_errors = TRUE;
+    }
+  }
+
+  if ($has_errors) {
+    throw new Exception('Installation failed. Please review errors above.');
+  }
+
+  return [
+    'postgres_username' => $options['db-username'],
+    'postgres_password' => $options['db-password'],
+    'host' => $options['db-host'],
+    'database' => $options['db-name'],
+    'port' => $options['db-port'],
+    'username' => $options['admin-username'],
+    'user_password' => $options['admin-password'],
+    'site_email' => $options['site-email'],
+    'site_name' => $options['site-name'],
+  ];
+}
+
+/**
+ * Get the settings by interactively prompting the user.
+ *
+ * @return array
+ */
+function tripal_install_get_settings_interactively() {
   //install.php input
   $site_settings = FALSE;
-  while(!$site_settings){
-    $site_name  = drush_prompt(dt('Name of the site '));
+  while (!$site_settings) {
+    $site_name = drush_prompt(dt('Name of the site '));
     //Validate email
     $valid_email = FALSE;
-    while(!$valid_email){
-      $site_email  = drush_prompt(dt('Admin email for the site '));
+    while (!$valid_email) {
+      $site_email = drush_prompt(dt('Admin email for the site '));
       if (filter_var($site_email, FILTER_VALIDATE_EMAIL)) {
         $valid_email = TRUE;
       }
@@ -69,8 +160,8 @@ function drush_tripal_install_install_prepare() {
         ));
       }
     }
-    $username  = drush_prompt(dt('Name for your admin user on the site '));
-    $user_password  = drush_prompt(dt('Password for the admin user, needs to be complex including numbers and characters, example P@55w0rd '));
+    $username = drush_prompt(dt('Name for your admin user on the site '));
+    $user_password = drush_prompt(dt('Password for the admin user, needs to be complex including numbers and characters, example P@55w0rd '));
     drush_print(dt(""));
     drush_print(dt(
       "These are the site settings provided, please review and confirm they are correct 
@@ -79,16 +170,15 @@ function drush_tripal_install_install_prepare() {
        Administrator username: $username
        Administrator password: $user_password"
     ));
-    $site_settings  = drush_confirm(dt('Is this information correct?'));
+    $site_settings = drush_confirm(dt('Is this information correct?'));
   }
   //settings.php input
   $settings_php = FALSE;
-  while(!$settings_php){
+  while (!$settings_php) {
     drush_print(dt(""));
     drush_print(dt(
       "Now we need to setup Drupal to connect to the database you want to use. These settings are added to Drupal's settings.php file.\n"
     ));
-    $driver = 'pgsql';
     $database = drush_prompt(dt('database name'));
     $postgres_username = drush_prompt(dt('postgres username'));
     $postgres_password = drush_prompt(dt('postgres password'));
@@ -103,102 +193,193 @@ function drush_tripal_install_install_prepare() {
        Database host: $host
        Database port: $port"
     ));
-    $settings_php  = drush_confirm(dt('Is this information correct?'));
+    $settings_php = drush_confirm(dt('Is this information correct?'));
   }
+
   drush_print(dt(""));
+
+  return [
+    'postgres_username' => $postgres_username,
+    'postgres_password' => $postgres_password,
+    'host' => $host,
+    'database' => $database,
+    'port' => $port,
+    'username' => $username,
+    'user_password' => $user_password,
+    'site_email' => $site_email,
+    'site_name' => $site_name,
+  ];
+}
+
+/**
+ * Perform the installation task.
+ *
+ * @param array $settings
+ *
+ * @throws \Exception
+ */
+function tripal_install_perform_tasks(array $settings) {
+  $driver = 'pgsql';
+  $postgres_username = $settings['postgres_username'];
+  $postgres_password = $settings['postgres_password'];
+  $host = $settings['host'];
+  $database = ['database'];
+  $port = $settings['port'];
+  $username = $settings['username'];
+  $user_password = $settings['user_password'];
+  $site_email = $settings['site_email'];
+  $site_name = $settings['site_name'];
+
   drush_print(dt("Now installing Drupal.\n"));
   //Download and install drupal core then move it up one directory level.
-  exec('wget https://www.drupal.org/files/projects/drupal-7.56.tar.gz');
-  exec('tar -zxvf drupal-7.56.tar.gz');
-  exec('mv drupal-7.56/* ./');
-  exec('mv drupal-7.56/.htaccess ./');
+  tripal_install_exec('wget https://www.drupal.org/files/projects/drupal-7.56.tar.gz');
+  tripal_install_exec('tar -zxvf drupal-7.56.tar.gz');
+  tripal_install_exec('mv drupal-7.56/* ./');
+  tripal_install_exec('mv drupal-7.56/.htaccess ./');
 
   //Arguments for the Drush site-install command.
-  $args = array(
+  $args = [
     'standard',
-    'install_configure_form.update_status_module=\'array(FALSE,FALSE)\''
-  );
+    'install_configure_form.update_status_module=\'array(FALSE,FALSE)\'',
+  ];
 
   //Options for the Drush site-install command.
-  $options = array(
-    '--db-url='. $driver . '://' . $postgres_username . ':' .$postgres_password .
-    '@' .$host. ':' . $port . '/' . $database,
-    '--account-name='. $username,
-    '--account-pass='. $user_password,
-    '--site-mail='. $site_email,
-    '--site-name='. $site_name
-  );
+  $options = [
+    '--db-url=' . $driver . '://' . $postgres_username . ':' . $postgres_password .
+    '@' . $host . ':' . $port . '/' . $database,
+    '--account-name=' . $username,
+    '--account-pass=' . $user_password,
+    '--site-mail=' . $site_email,
+    '--site-name=' . $site_name,
+  ];
   $install = drush_invoke_process('@self', 'si', $args, $options);
   drush_print(dt(""));
   if (!$install) {
-    echo "An error occurred when attempting to install Drupal. If you would like to try again please remove any files or tables created during this intial installation attempt.\n";
-    exit;
+    throw new Exception("An error occurred when attempting to install Drupal.
+                          If you would like to try again please remove any files
+                          or tables created during this intial installation attempt.");
   }
   print_r("Downloading modules.\n");
-  $args = array('field_group', 'field_group_table', 'field_formatter_class', 'field_formatter_settings',
-    'ctools', 'date', 'devel', 'ds', 'link', 'entity', 'libraries', 'redirect',
-    'token', 'tripal-7.x-3.0-rc2', 'uuid', 'jquery_update', 'views', 'webform');
-  $options = array();
-  drush_invoke_process('@self', 'dl', $args, $options);
+  $args = [
+    'field_group',
+    'field_group_table',
+    'field_formatter_class',
+    'field_formatter_settings',
+    'ctools',
+    'date',
+    'devel',
+    'ds',
+    'link',
+    'entity',
+    'libraries',
+    'redirect',
+    'token',
+    'tripal-7.x-3.0-rc2',
+    'uuid',
+    'jquery_update',
+    'views',
+    'webform',
+  ];
+  $options = [];
+  $download = drush_invoke_process('@self', 'dl', $args, $options);
+  if($download === false) {
+    throw new Exception("Unable to download modules.");
+  }
   drush_print(dt(""));
   print_r("Enabling modules.\n");
-  $args2 = array('ctools', 'date', 'devel', 'ds', 'link', 'entity', 'libraries', 'redirect',
-    'token', 'uuid', 'jquery_update', 'views', 'webform', 'field_group',
-    'field_group_table', 'field_formatter_class', 'field_formatter_settings',
-    'views_ui');
-  $options2 = array();
-  drush_invoke_process('@self', 'en', $args2, $options2);
+  $args2 = [
+    'ctools',
+    'date',
+    'devel',
+    'ds',
+    'link',
+    'entity',
+    'libraries',
+    'redirect',
+    'token',
+    'uuid',
+    'jquery_update',
+    'views',
+    'webform',
+    'field_group',
+    'field_group_table',
+    'field_formatter_class',
+    'field_formatter_settings',
+    'views_ui',
+  ];
+  $options2 = [];
+  $enable = drush_invoke_process('@self', 'en', $args2, $options2);
+  if($enable === false) {
+    throw new Exception('Unable to enable modules');
+  }
   drush_print(dt("\n"));
   print_r("Applying patches.\n");
   //apply patches
   $current_working_directory = getcwd();
-  exec('wget --no-check-certificate https://drupal.org/files/drupal.pgsql-bytea.27.patch');
-  exec('patch -p1 < drupal.pgsql-bytea.27.patch');
+  tripal_install_exec('wget --no-check-certificate https://drupal.org/files/drupal.pgsql-bytea.27.patch');
+  tripal_install_exec('patch -p1 < drupal.pgsql-bytea.27.patch');
   chdir($current_working_directory . "/sites/all/modules/views");
-  exec('patch -p1 < ../tripal/tripal_chado_views/views-sql-compliant-three-tier-naming-1971160-30.patch');
+  tripal_install_exec('patch -p1 < ../tripal/tripal_chado_views/views-sql-compliant-three-tier-naming-1971160-30.patch');
   chdir('.');
   drush_print(dt(""));
   print_r("Enabling Tripal modules.\n");
-  $args3 = array('tripal', 'tripal_chado', 'tripal_ds', 'tripal_ws');
-  $options3 = array();
+  $args3 = ['tripal', 'tripal_chado', 'tripal_ds', 'tripal_ws'];
+  $options3 = [];
   $tripal = drush_invoke_process('@self', 'en', $args3, $options3);
   drush_print(dt(""));
-  if (!$tripal) {
-    echo "An error occurred when attempting to enable Tripal. Please navigate to your new site and finish the installation process from the 'Install Tripal' section as described in the online help, found here http://tripal.info/tutorials/v3.x/installation/tripal \n";
-    exit;
+  if ($tripal === false) {
+    throw new Exception("An error occurred when attempting to enable Tripal.
+                        Please navigate to your new site and finish the 
+                        installation process from the 'Install Tripal' section
+                        as described in the online help, found here
+                        http://tripal.info/tutorials/v3.x/installation/tripal");
   }
   drush_print(dt(""));
   print_r("Clear cache.\n");
-  drush_invoke_process("@site", "cc", array("all"), array("verbose"));
+  $clear_cache = drush_invoke_process("@site", "cc", ["all"], ["verbose"]);
+  if($clear_cache === false) {
+    throw new Exception("Unable to clear the site's cache.");
+  }
   drush_print(dt(""));
   print_r("Installing Chado.\n");
-  $options = array(
-    'Install Chado v1.3' => 'Install Chado v1.3',
-    'Install Chado v1.2' => 'Install Chado v1.2',
-    'Install Chado v1.11' => 'Install Chado v1.11',
-  );
-  $version = drush_choice($options, dt('Which version of Chado would you like installed?'));
+
+  if (drush_get_option('interactive', TRUE)) {
+    $options = [
+      'Install Chado v1.3' => 'Install Chado v1.3',
+      'Install Chado v1.2' => 'Install Chado v1.2',
+      'Install Chado v1.11' => 'Install Chado v1.11',
+    ];
+    $version = drush_choice($options, dt('Which version of Chado would you like installed?'));
+  }
+  else {
+    $version = intval(drush_get_option('chado_version', 0));
+  }
 
   if ($version) {
-    if($version == 'Install Chado v1.3') {
-      $chado = drush_invoke_process('@self', 'php-eval', array("module_load_include('inc', 'tripal_chado', 'includes/tripal_chado.install'); tripal_chado_load_drush_submit('Install Chado v1.3');"), array());
+    if ($version == 'Install Chado v1.3' || $version === 1) {
+      $chado = drush_invoke_process('@self', 'php-eval', ["module_load_include('inc', 'tripal_chado', 'includes/tripal_chado.install'); tripal_chado_load_drush_submit('Install Chado v1.3');"], []);
     }
-    elseif($version == 'Install Chado v1.2') {
-      $chado = drush_invoke_process('@self', 'php-eval', array("module_load_include('inc', 'tripal_chado', 'includes/tripal_chado.install'); tripal_chado_load_drush_submit('Install Chado v1.2');"), array());
+    elseif ($version == 'Install Chado v1.2' || $version === 2) {
+      $chado = drush_invoke_process('@self', 'php-eval', ["module_load_include('inc', 'tripal_chado', 'includes/tripal_chado.install'); tripal_chado_load_drush_submit('Install Chado v1.2');"], []);
     }
-    elseif($version == 'Install Chado v1.11') {
-      $chado = drush_invoke_process('@self', 'php-eval', array("module_load_include('inc', 'tripal_chado', 'includes/tripal_chado.install'); tripal_chado_load_drush_submit('Install Chado v1.11');"), array());
+    elseif ($version == 'Install Chado v1.11' || $version === 3) {
+      $chado = drush_invoke_process('@self', 'php-eval', ["module_load_include('inc', 'tripal_chado', 'includes/tripal_chado.install'); tripal_chado_load_drush_submit('Install Chado v1.11');"], []);
+    } else {
+      $chado = true;
+    }
+    if($chado === false) {
+      throw new Exception("Failed to install chado");
     }
   }
-  drush_invoke_process('@self', 'php-eval', array("module_load_include('inc', 'tripal', 'tripal.drush'); drush_tripal_trp_run_jobs_install(" . $username . ");"), array());
+  drush_invoke_process('@self', 'php-eval', ["module_load_include('inc', 'tripal', 'tripal.drush'); drush_tripal_trp_run_jobs_install(" . $username . ");"], []);
   drush_print(dt(""));
   if (!$tripal) {
     echo "An error occurred when attempting to install Chado. Please navigate to your new site and finish the installation process from the 'Install Tripal' section as described in the online help, found here http://tripal.info/tutorials/v3.x/installation/tripal \n";
     exit;
   }
   print_r("Now preparing the site by creating content types.\n");
-  $prepare = drush_invoke_process('@self', 'php-eval', array("module_load_include('inc', 'tripal_chado', 'includes/setup/tripal_chado.setup'); tripal_chado_prepare_drush_submit();"), array());
-  drush_invoke_process('@self', 'php-eval', array("module_load_include('inc', 'tripal', 'tripal.drush'); drush_tripal_trp_run_jobs_install(" . $username . ");"), array());
+  $prepare = drush_invoke_process('@self', 'php-eval', ["module_load_include('inc', 'tripal_chado', 'includes/setup/tripal_chado.setup'); tripal_chado_prepare_drush_submit();"], []);
+  drush_invoke_process('@self', 'php-eval', ["module_load_include('inc', 'tripal', 'tripal.drush'); drush_tripal_trp_run_jobs_install(" . $username . ");"], []);
   if (!$prepare) {
     echo "An error occurred when attempting to install Chado. Please navigate to your new site and finish the installation process from the 'Install Tripal' section as described in the online help, found here http://tripal.info/tutorials/v3.x/installation/tripal \n";
     exit;
@@ -206,8 +387,8 @@ function drush_tripal_install_install_prepare() {
   //Get all the content types and add the permissions.
   drush_print(dt(""));
   print_r("Adding permissions for the administrator to view, edit, create, and delete all the newly created content types.\n");
-  $permissions = array();
-  $bundles = array();
+  $permissions = [];
+  $bundles = [];
   $conn = pg_pconnect("host=$host dbname=$database user=$postgres_username password=$postgres_password");
   if (!$conn) {
     echo "An error occurred when attempting to perimssion the administrator. Please navigate to your new site and add permissions to your new content types here admin/people/permissions.\n";
@@ -222,15 +403,30 @@ function drush_tripal_install_install_prepare() {
   while ($row = pg_fetch_row($result)) {
     array_push($bundles, $row);
   }
-  foreach($bundles as $bundles=>$bundle){
+  foreach ($bundles as $bundle) {
     array_push($permissions, ' view ' . $bundle[0], ' create ' . $bundle[0],
-      ' edit ' . $bundle[0],  ' delete ' . $bundle[0]);
+      ' edit ' . $bundle[0], ' delete ' . $bundle[0]);
   }
   $string_permissions = implode(",", $permissions);
-  $args4 = array('administrator', $string_permissions);
-  $options4 = array();
+  $args4 = ['administrator', $string_permissions];
+  $options4 = [];
   drush_invoke_process('@self', 'role-add-perm', $args4, $options4);
 
   drush_print(dt(""));
   drush_print(dt("Installation is now complete. You may navigate to your new site. For more information on using Tripal please see the installation guide on tripal.info."));
+}
+
+/**
+ * A wrapper around exec to detect commands that did not complete successfully.
+ *
+ * @param $command
+ *
+ * @throws \Exception
+ */
+function tripal_install_exec($command) {
+  exec($command, $output, $return_var);
+
+  if ($return_var !== 0) {
+    throw new Exception("$command failed to execute successfully.");
+  }
 }


### PR DESCRIPTION
Hello,

This pull request adds travis CI integration to tripal_install. To make this possible we had to refactor the code to accept a non-interactive mode where all the options are passed through the cli. 

However, since we don't own the repo we couldn't validate the travis yaml file. But that should automatically happens once you enable travis on your end before merging this pull request. From there, we can update the code until it passes then merge.

Please let me know if you have any questions.

Thanks!