### PR TITLE
Enable Tripal version 7.34 of tripal instead of 7.35

### DIFF
--- a/tripal_install.drush.inc
+++ b/tripal_install.drush.inc
@@ -137,7 +137,7 @@ function drush_tripal_install_install_prepare() {
   print_r("Downloading modules.\n");
   $args = array('field_group', 'field_group_table', 'field_formatter_class', 'field_formatter_settings',
     'ctools', 'date', 'devel', 'ds', 'link', 'entity', 'libraries', 'redirect',
-    'token', 'tripal-7.x-3.5', 'uuid', 'jquery_update', 'views', 'webform');
+    'token', 'tripal-7.x-3.4', 'uuid', 'jquery_update', 'views', 'webform');
   $options = array();
   drush_invoke_process('@self', 'dl', $args, $options);
   drush_print(dt(""));


### PR DESCRIPTION
Reference is made to the current issue https://github.com/tripal/tripal/issues/1162 in which installing Tripal 3 via the drush command fails:

`drush --include=. tripal-generic-install`

It's because 3.5 isn't released as yet, this adjusts the version back to 3.4

